### PR TITLE
Make it work with latest Huggingface Transformers

### DIFF
--- a/longformer/longformer.py
+++ b/longformer/longformer.py
@@ -77,7 +77,7 @@ class LongformerSelfAttention(nn.Module):
         assert self.attention_dilation > 0
         self.autoregressive = config.autoregressive
 
-    def forward(self, hidden_states, attention_mask=None, head_mask=None, *args, **kwargs):
+    def forward(self, hidden_states, attention_mask=None, head_mask=None, encoder_hidden_states=None, encoder_attention_mask=None):
         '''
         The `attention_mask` is changed in BertModel.forward from 0, 1, 2 to
             -ve: no attention

--- a/longformer/longformer.py
+++ b/longformer/longformer.py
@@ -77,7 +77,7 @@ class LongformerSelfAttention(nn.Module):
         assert self.attention_dilation > 0
         self.autoregressive = config.autoregressive
 
-    def forward(self, hidden_states, attention_mask=None, head_mask=None):
+    def forward(self, hidden_states, attention_mask=None, head_mask=None, *args, **kwargs):
         '''
         The `attention_mask` is changed in BertModel.forward from 0, 1, 2 to
             -ve: no attention


### PR DESCRIPTION
It seems between version 2.0 and the current one, they added two optional arguments to `BertSelfAttention.forward()`, namely:
encoder_hidden_states=None,
encoder_attention_mask=None,
so it can work as a cross-attention module. It breaks because there are too many arguments, but it works alright after this change.