### PR TITLE
PyTorch implementation of sliding window attention + variable global attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ We added a PyTorch implementation of the sliding window attention that doesn't r
 - Uses 2x more memory (but fp16 offsets that)
 - Doesn’t support dilation and autoregressive attention (not needed for finetuning)
 
-Therefor, it is suitable for finetuning on dowstream tasks but not a good choice for language modeling. 
-
-The code snippit below and the TriviaQA scripts were updated to use this new implementation.
+Therefor, it is suitable for finetuning on dowstream tasks but not a good choice for language modeling. The code snippit below and the TriviaQA scripts were updated to use this new implementation.
 
 **\*\*\*\*\* End new information \*\*\*\*\***
 
@@ -45,7 +43,7 @@ The code snippit below and the TriviaQA scripts were updated to use this new imp
     # 'n2': for regular n2 attantion
     # 'tvm': a custom CUDA kernel implementation of our sliding window attention
     # 'sliding_chunks': a PyTorch implementation of our sliding window attention
-    config.attention_mode = 'sliding_chunks'  # 'tvm' and 'sliding_chunks'
+    config.attention_mode = 'sliding_chunks'
 
     model = Longformer.from_pretrained('longformer-base-4096/', config=config)
     tokenizer = RobertaTokenizer.from_pretrained('roberta-base')
@@ -82,7 +80,7 @@ The code snippit below and the TriviaQA scripts were updated to use this new imp
 
 ### CUDA kernel
 
-Our custom CUDA kernel is implemented in TVM.  For now, the kernel only works on GPUs and Linux. We tested it code on Ubuntu, Python 3.7, CUDA10, PyTorch 1.2.0. If it doesn't work for your environment, please create a new issue.
+Our custom CUDA kernel is implemented in TVM.  For now, the kernel only works on GPUs and Linux. We tested it on Ubuntu, Python 3.7, CUDA10, PyTorch 1.2.0. If it doesn't work for your environment, please create a new issue.
 
 **Compiling the kernel**: We already include the compiled binaries of the CUDA kernel, so most users won't need to compile it, but if you are intersted, check `scripts/cheatsheet.txt` for instructions.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ We added a PyTorch implementation of the sliding window attention that doesn't r
 
 **Advantage**: supports CPU, TPU and fp16, which aren't supported by the custom CUDA kernel
 
-**Limitations**:
-- Uses 2x more memory (but fp16 offsets that)
-- Doesn’t support dilation and autoregressive attention (not needed for finetuning)
+**Limitations**: uses 2x more memory (but fp16 offsets that), and doesn’t support dilation and autoregressive attention (not needed for finetuning)
 
 Therefor, it is suitable for finetuning on dowstream tasks but not a good choice for language modeling. The code snippit below and the TriviaQA scripts were updated to use this new implementation.
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 We added a PyTorch implementation of the sliding window attention that doesn't require the custom CUDA kernel. It is limited in functionality but more convenient to use for finetuning on downstream tasks. 
 
-Advantage: No custom CUDA kernel means support for CPU, TPU and fp16, which weren’t previously supported
+**Advantage**: No custom CUDA kernel means support for CPU, TPU and fp16, which weren’t previously supported
 
-Limitations:
+**Limitations**:
 - Uses 2x more memory than our custom CUDA kernel (but fp16 offsets that)
-- Doesn’t support dilation and autoregressive attention
+- Doesn’t support dilation and autoregressive attention (not needed for finetuning)
 
-Therefor, it is suitable for finetuning on dowstream tasks (no dilation, fp16 reduces memory) but not a good choice for language modeling. 
+Therefor, it is suitable for finetuning on dowstream tasks but not a good choice for language modeling. 
 
 The code snippit below and the TriviaQA scripts were updated to use this new implementation.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # <p align=center>`Longformer`</p>
 `Longformer` is a BERT-like model for long documents.
 
+**\*\*\*\*\* New April 27th, 2020: A PyToch implementation of the sliding window attention  \*\*\*\*\***
+
+We added a PyTorch implementation of the sliding window attention that doesn't require the custom CUDA kernel. It is limited in functionality but more convenient to use for finetuning on downstream tasks. 
+
+Limitations: 
+- Uses 2x more memory than our custom CUDA kernel
+- Only works for the no-dilation case
+- Doesn't support the autoregressive case
+- As a result, it is not suitable for language modeling
+
+However: 
+- No custom CUDA kernel means it works on all devices including CPU and TPU (which the CUDA kernel doesn't support)
+- Supports FP16, which offsets the 2x memory increase
+- Our pretrained model doesn't use dilation making this implementation a good choise for finetuning on downstream tasks
+
+The code snippit below and the TriviaQA scripts are updated to use this new implementation.
+
+**\*\*\*\*\* End new information \*\*\*\*\***
+
 ### How to use
 
 1. Download pretrained model
@@ -24,7 +43,7 @@
     import torch
     from longformer.longformer import Longformer
     from transformers import RobertaTokenizer
-
+    # TODO: update to use slidingchunks
     model = Longformer.from_pretrained('longformer-base-4096/')
     tokenizer = RobertaTokenizer.from_pretrained('roberta-base')
     tokenizer.max_len = model.config.max_position_embeddings

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 We added a PyTorch implementation of the sliding window attention that doesn't require the custom CUDA kernel. It is limited in functionality but more convenient to use for finetuning on downstream tasks. 
 
-**Advantage**: No custom CUDA kernel means support for CPU, TPU and fp16, which weren’t previously supported
+**Advantage**: supports CPU, TPU and fp16, which aren't supported by the custom CUDA kernel
 
 **Limitations**:
-- Uses 2x more memory than our custom CUDA kernel (but fp16 offsets that)
+- Uses 2x more memory (but fp16 offsets that)
 - Doesn’t support dilation and autoregressive attention (not needed for finetuning)
 
 Therefor, it is suitable for finetuning on dowstream tasks but not a good choice for language modeling. 
@@ -24,8 +24,6 @@ The code snippit below and the TriviaQA scripts were updated to use this new imp
   * [`longformer-large-4096`](https://ai2-s2-research.s3-us-west-2.amazonaws.com/longformer/longformer-large-4096.tar.gz)
 
 2. Install environment and code
-
-    Our code relies on a custom CUDA kernel, and for now it only works on GPUs and Linux. We tested our code on Ubuntu, Python 3.7, CUDA10, PyTorch 1.2.0. If it doesn't work for your environment, please create a new issue.
 
     ```bash
     conda create --name longformer python=3.7
@@ -58,7 +56,7 @@ The code snippit below and the TriviaQA scripts were updated to use this new imp
  
     input_ids = torch.tensor(tokenizer.encode(SAMPLE_TEXT)).unsqueeze(0)  # batch of size 1
 
-    # TVM code doesn't work on CPU. Uncomment this for `config.attention_mode = 'tvm'`
+    # TVM code doesn't work on CPU. Uncomment this if `config.attention_mode = 'tvm'`
     # model = model.cuda(); input_ids = input_ids.cuda()
 
     # Attention mask values -- 0: no attention, 1: local attention, 2: global attention
@@ -82,9 +80,11 @@ The code snippit below and the TriviaQA scripts were updated to use this new imp
 * Instructions: `scripts/cheatsheet.txt`
 
 
-### Compiling the CUDA kernel
+### CUDA kernel
 
-We already include the compiled binaries of the CUDA kernel, so most users won't need to compile it, but if you are intersted, check `scripts/cheatsheet.txt` for instructions.
+Our custom CUDA kernel is implemented in TVM.  For now, the kernel only works on GPUs and Linux. We tested it code on Ubuntu, Python 3.7, CUDA10, PyTorch 1.2.0. If it doesn't work for your environment, please create a new issue.
+
+**Compiling the kernel**: We already include the compiled binaries of the CUDA kernel, so most users won't need to compile it, but if you are intersted, check `scripts/cheatsheet.txt` for instructions.
 
 
 ### Known issues

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The code snippit below and the TriviaQA scripts are updated to use this new impl
     attention_mask = torch.ones(input_ids.shape, dtype=torch.long, device=input_ids.device) # initialize to local attention
     attention_mask[:, [1, 4, 21,]] =  2  # Set global attention based on the task. For example,
                                          # classification: the <s> token
-                                         # QA: question tokenss
+                                         # QA: question tokens
 
     # padding seqlen to the nearest multiple of 512. Needed for the 'sliding_chunks' attention
     input_ids, attention_mask = pad_to_window_size(

--- a/README.md
+++ b/README.md
@@ -5,17 +5,15 @@
 
 We added a PyTorch implementation of the sliding window attention that doesn't require the custom CUDA kernel. It is limited in functionality but more convenient to use for finetuning on downstream tasks. 
 
-Limitations: 
-- Uses 2x more memory than our custom CUDA kernel
-- Only works for the no-dilation case, and doesn't support the autoregressive case
-- As a result, it is not suitable for language modeling
+Advantage: No custom CUDA kernel means support for CPU, TPU and fp16, which weren’t previously supported
 
-However: 
-- No custom CUDA kernel means it works on all devices including CPU and TPU (which the CUDA kernel doesn't support)
-- Supports FP16, which offsets the 2x memory increase
-- Our pretrained model doesn't use dilation, making this implementation a good choice for finetuning on downstream tasks
+Limitations:
+- Uses 2x more memory than our custom CUDA kernel (but fp16 offsets that)
+- Doesn’t support dilation and autoregressive attention
 
-The code snippit below and the TriviaQA scripts are updated to use this new implementation.
+Therefor, it is suitable for finetuning on dowstream tasks (no dilation, fp16 reduces memory) but not a good choice for language modeling. 
+
+The code snippit below and the TriviaQA scripts were updated to use this new implementation.
 
 **\*\*\*\*\* End new information \*\*\*\*\***
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <p align=center>`Longformer`</p>
 `Longformer` is a BERT-like model for long documents.
 
-**\*\*\*\*\* New April 27th, 2020: A PyToch implementation of the sliding window attention  \*\*\*\*\***
+**\*\*\*\*\* New April 27th, 2020: A PyTorch implementation of the sliding window attention  \*\*\*\*\***
 
 We added a PyTorch implementation of the sliding window attention that doesn't require the custom CUDA kernel. It is limited in functionality but more convenient to use for finetuning on downstream tasks. 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
     input_ids = torch.tensor(tokenizer.encode(SAMPLE_TEXT)).unsqueeze(0)  # batch of size 1
 
     model = model.cuda()  # doesn't work on CPU
-    input_ids = input_ids.cuda()   
+    input_ids = input_ids.cuda()
 
     # Attention mask values -- 0: no attention, 1: local attention, 2: global attention
     attention_mask = torch.ones(input_ids.shape, dtype=torch.long, device=input_ids.device) # initialize to local attention

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Limitations:
 However: 
 - No custom CUDA kernel means it works on all devices including CPU and TPU (which the CUDA kernel doesn't support)
 - Supports FP16, which offsets the 2x memory increase
-- Our pretrained model doesn't use dilation making this implementation a good choise for finetuning on downstream tasks
+- Our pretrained model doesn't use dilation making this implementation a good choice for finetuning on downstream tasks
 
 The code snippit below and the TriviaQA scripts are updated to use this new implementation.
 

--- a/longformer/diagonaled_mm_tvm.py
+++ b/longformer/diagonaled_mm_tvm.py
@@ -325,5 +325,6 @@ def mask_invalid_locations(input_tensor: torch.Tensor, w: int, d: Union[torch.Te
 
 
 diagonaled_mm = DiagonaledMM.apply
-# Loading these functions doesn't seem to be threadsafe. Instead, load them once before multigpu
-DiagonaledMM._get_function('float32', 'cuda')
+
+# The non-tvm implementation is the default, we don't need to load the kernel at loading time.
+# DiagonaledMM._get_function('float32', 'cuda')

--- a/longformer/sliding_chunks.py
+++ b/longformer/sliding_chunks.py
@@ -1,0 +1,133 @@
+import torch
+import torch.nn.functional as F
+from longformer.diagonaled_mm_tvm import mask_invalid_locations
+
+
+def _skew(x, direction, padding_value):
+    '''Convert diagonals into columns (or columns into diagonals depending on `direction`'''
+    x_padded = F.pad(x, direction, value=padding_value)
+    x_padded = x_padded.view(*x_padded.size()[:-2], x_padded.size(-1), x_padded.size(-2))
+    return x_padded
+
+
+def _skew2(x, padding_value):
+    '''shift every row 1 step to right converting columns into diagonals'''
+    # X = B x C x M x L
+    B, C, M, L = x.size()
+    x = F.pad(x, (0, M + 1), value=padding_value)  # B x C x M x (L+M+1)
+    x = x.view(B, C, -1)  # B x C x ML+MM+M
+    x = x[:, :, :-M]  # B x C x ML+MM
+    x = x.view(B, C, M, M + L)  # B x C, M x L+M
+    x = x[:, :, :, :-1]
+    return x
+
+
+def _chunk(x, w):
+    '''convert into overlapping chunkings. Chunk size = 2w, overlap size = w'''
+
+    # non-overlapping chunks of size = 2w
+    x = x.view(x.size(0), x.size(1) // (w * 2), w * 2, x.size(2))
+
+    # use `as_strided` to make the chunks overlap with an overlap size = w
+    chunk_size = list(x.size())
+    chunk_size[1] = chunk_size[1] * 2 - 1
+
+    chunk_stride = list(x.stride())
+    chunk_stride[1] = chunk_stride[1] // 2
+    return x.as_strided(size=chunk_size, stride=chunk_stride)
+
+
+def sliding_chunks_matmul_qk(q: torch.Tensor, k: torch.Tensor, w: int, padding_value: float):
+    '''Matrix multiplicatio of query x key tensors using with a sliding window attention pattern.
+    This implementation splits the input into overlapping chunks of size 2w (e.g. 512 for pretrained Longformer)
+    with an overlap of size'''
+    bsz, seqlen, num_heads, head_dim = q.size()
+    assert seqlen % (w * 2) == 0
+    assert q.size() == k.size()
+
+    chunks_count = seqlen // w - 1
+
+    # group bsz and num_heads dimensions into one, then chunk seqlen into chunks of size w * 2
+    q = q.transpose(1, 2).reshape(bsz * num_heads, seqlen, head_dim)
+    k = k.transpose(1, 2).reshape(bsz * num_heads, seqlen, head_dim)
+
+    chunk_q = _chunk(q, w)
+    chunk_k = _chunk(k, w)
+
+    # matrix multipication
+    # bcxd: bsz*num_heads x chunks x 2w x head_dim
+    # bcyd: bsz*num_heads x chunks x 2w x head_dim
+    # bcxy: bsz*num_heads x chunks x 2w x 2w
+    chunk_attn = torch.einsum('bcxd,bcyd->bcxy', (chunk_q, chunk_k))  # multiply
+
+    # convert diagonals into columns
+    diagonal_chunk_attn = _skew(chunk_attn, direction=(0, 0, 0, 1), padding_value=padding_value)
+
+    # allocate space for the overall attention matrix where the chunks are compined. The last dimension
+    # has (w * 2 + 1) columns. The first (w) columns are the w lower triangles (attention from a word to
+    # w previous words). The following column is attention score from each word to itself, then
+    # followed by w columns for the upper triangle.
+
+    diagonal_attn = diagonal_chunk_attn.new_empty((bsz * num_heads, chunks_count + 1, w, w * 2 + 1))
+
+    # copy parts from diagonal_chunk_attn into the compined matrix of attentions
+    # - copying the main diagonal and the upper triangle
+    diagonal_attn[:, :-1, :, w:] = diagonal_chunk_attn[:, :, :w, :w + 1]
+    diagonal_attn[:, -1, :, w:] = diagonal_chunk_attn[:, -1, w:, :w + 1]
+    # - copying the lower triangle
+    diagonal_attn[:, 1:, :, :w] = diagonal_chunk_attn[:, :, - (w + 1):-1, w + 1:]
+    diagonal_attn[:, 0, 1:w, 1:w] = diagonal_chunk_attn[:, 0, :w - 1, 1 - w:]
+
+    # separate bsz and num_heads dimensions again
+    diagonal_attn = diagonal_attn.view(bsz, num_heads, seqlen, 2 * w + 1).transpose(2, 1)
+
+    mask_invalid_locations(diagonal_attn, w, 1, False)
+    return diagonal_attn
+
+
+def sliding_chunks_matmul_pv(prob: torch.Tensor, v: torch.Tensor, w: int):
+    '''Same as sliding_chunks_matmul_qk but for prob and value tensors. It is expecting the same output
+    format from sliding_chunks_matmul_qk'''
+    bsz, seqlen, num_heads, head_dim = v.size()
+    assert seqlen % (w * 2) == 0
+    assert prob.size()[:3] == v.size()[:3]
+    assert prob.size(3) == 2 * w + 1
+    chunks_count = seqlen // w - 1
+    # group bsz and num_heads dimensions into one, then chunk seqlen into chunks of size 2w
+    chunk_prob = prob.transpose(1, 2).reshape(bsz * num_heads, seqlen // w, w, 2 * w + 1)
+
+    # group bsz and num_heads dimensions into one
+    v = v.transpose(1, 2).reshape(bsz * num_heads, seqlen, head_dim)
+
+    # pad seqlen with w at the beginning of the sequence and another w at the end
+    padded_v = F.pad(v, (0, 0, w, w), value=-1)
+
+    # chunk padded_v into chunks of size 3w and an overlap of size w
+    chunk_v_size = (bsz * num_heads, chunks_count + 1, 3 * w, head_dim)
+    chunk_v_stride = padded_v.stride()
+    chunk_v_stride = chunk_v_stride[0], w * chunk_v_stride[1], chunk_v_stride[1], chunk_v_stride[2]
+    chunk_v = padded_v.as_strided(size=chunk_v_size, stride=chunk_v_stride)
+
+    skewed_prob = _skew2(chunk_prob, padding_value=0)
+
+    context = torch.einsum('bcwd,bcdh->bcwh', (skewed_prob, chunk_v))
+    return context.view(bsz, num_heads, seqlen, head_dim).transpose(1, 2)
+
+
+def pad_to_window_size(input_ids: torch.Tensor, attention_mask: torch.Tensor,
+                       one_sided_window_size: int, pad_token_id: int):
+    '''A helper function to pad tokens and mask to work with the sliding_chunks implementation of Longformer selfattention.
+    Input:
+        input_ids = torch.Tensor(bsz x seqlen): ids of wordpieces
+        attention_mask = torch.Tensor(bsz x seqlen): attention mask
+        one_sided_window_size = int: window size on one side of each token
+        pad_token_id = int: tokenizer.pad_token_id
+    Returns
+        (input_ids, attention_mask) padded to length divisible by 2 * one_sided_window_size
+    '''
+    w = 2 * one_sided_window_size
+    seqlen = input_ids.size(1)
+    padding_len = (w - seqlen % w) % w
+    input_ids = F.pad(input_ids, (0, padding_len), value=pad_token_id)
+    attention_mask = F.pad(attention_mask, (0, padding_len), value=False)  # no attention on the padding tokens
+    return input_ids, attention_mask

--- a/tests/test_sliding_chunks.py
+++ b/tests/test_sliding_chunks.py
@@ -1,0 +1,85 @@
+import time
+import unittest
+import torch
+import numpy as np
+import random
+from longformer.diagonaled_mm_tvm import diagonaled_mm as diagonaled_mm_tvm, mask_invalid_locations
+from longformer.sliding_chunks import sliding_chunks_matmul_pv, sliding_chunks_matmul_qk
+
+
+def same_storage(x, y):
+    '''Tests if two tensors share the same underlying storage (for memory optimizations)'''
+    return x.storage().data_ptr() == y.storage().data_ptr()
+
+
+class TestSlidingChunksMM(unittest.TestCase):
+    def test_tvm_equal_sliding_chunks(self):
+        np.random.seed(3)
+        random.seed(3)
+        torch.manual_seed(3)
+        torch.cuda.manual_seed(3)
+        torch.cuda.manual_seed_all(3)
+
+        torch.set_printoptions(sci_mode=False)
+        N = 4096  # * 16
+        M = 64  # hidden size
+        W = 256  # one sided. Actual window size = 2w+1
+        B = 3
+        D = 1  # no dilation
+        H = 12  # number of heads
+        autoregressive = False  # not autoregressive
+        device = 'cuda'
+        dtype = torch.float32
+
+        failed_tests = 0
+        time1 = time2 = 0
+        for i in range(50):
+            if i < 5:
+                time1 = time2 = 0  # don't include the first few iterations because of high variance
+
+            query = torch.randn(B * N * H * M, requires_grad=True, device=device, dtype=dtype).view(B, N, H, M)
+            key = torch.randn(B * N * H * M, requires_grad=True, device=device, dtype=dtype).flip(dims=(0,)).view(B, N, H, M)
+            value = torch.randn(B * N * H * M, requires_grad=True, device=device, dtype=dtype).view(B, N, H, M)
+
+            # TVM MM
+            torch.cuda.synchronize()
+            start = time.time()
+            attention1 = diagonaled_mm_tvm(query, key, W, D, False, 0, autoregressive)
+            mask_invalid_locations(attention1, W, D, autoregressive)
+            attention_probs1 = torch.nn.functional.softmax(attention1, dim=-1)
+            context1 = diagonaled_mm_tvm(attention_probs1, value, W, D, True, 0, autoregressive)
+            context1.sum().backward()
+            torch.cuda.synchronize()
+            time1 += time.time() - start
+            torch.cuda.empty_cache()
+
+            # query = query.half()  # uncomment to profile the fp16 performance
+            # key = key.half()
+            # value = value.half()
+            assert D == 1
+            assert not autoregressive
+            torch.cuda.synchronize()
+            start = time.time()
+            attention2 = sliding_chunks_matmul_qk(query, key, W, float('-inf'))
+            attention_probs2 = torch.nn.functional.softmax(attention2, dim=-1)
+            context2 = sliding_chunks_matmul_pv(attention_probs2, value, W)
+            context2.sum().backward()
+            torch.cuda.synchronize()
+            time2 += time.time() - start
+            torch.cuda.empty_cache()
+
+            try:
+                assert torch.allclose(attention1, attention2.float(), atol=1e-4, rtol=1e-5)
+                assert torch.allclose(context1, context2.float(), atol=1e-4, rtol=1e-5)
+            except AssertionError:
+                failed_tests += 1
+
+        print('Time tvm: {0:.5f} s'.format(time1))
+        print('Time pytorch sliding chunks: {0:.5f} s'.format(time2))
+        print('Sliding chunks vs. TVM speedup: {0:.5f}x'.format(time1/time2))
+        print(f'Failed tests: {failed_tests}/{i+1}')
+        assert failed_tests == 0
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_var_global_attn.py
+++ b/tests/test_var_global_attn.py
@@ -1,0 +1,74 @@
+import torch
+import unittest
+import numpy as np
+import random
+from longformer.longformer import LongformerSelfAttention, LongformerConfig
+
+
+class TestLongformerSelfAttention(unittest.TestCase):
+
+    def _run_test(self, attn, hidden_state, attention_mask):
+        output3 = attn(hidden_states=hidden_state, attention_mask=attention_mask if attention_mask is not None else None)[0]
+
+        output1 = attn(hidden_states=hidden_state[:1], attention_mask=attention_mask[:1] if attention_mask is not None else None)[0]
+        output2 = attn(hidden_states=hidden_state[1:], attention_mask=attention_mask[1:] if attention_mask is not None else None)[0]
+        self.assertTrue(torch.allclose(output3, torch.cat((output1, output2), dim=0), atol=1e-7))
+        return output3
+
+    def test_selfattention(self):
+        np.random.seed(1)
+        random.seed(1)
+        torch.manual_seed(1)
+        torch.cuda.manual_seed(1)
+        torch.cuda.manual_seed_all(1)
+
+        seqlen = 1024
+        embed_dim = 60
+        num_heads = 3
+        bsz = 3
+        config = LongformerConfig()
+        config.num_attention_heads = num_heads
+        config.hidden_size = embed_dim
+        config.attention_probs_dropout_prob = 0.0
+        config.attention_window = [256]
+        config.attention_dilation = [1]
+        config.attention_mode = 'sliding_chunks'
+        config.autoregressive = False
+
+        attn = LongformerSelfAttention(config=config, layer_id=0)
+
+        hidden_state = torch.randn(bsz, seqlen, embed_dim)
+        attention_mask = torch.zeros((bsz, 1, 1, seqlen), dtype=torch.int)  # local attention everywhere
+
+        # test None attention_mask (default which is local attention everywhere)
+        output_nonemask = self._run_test(attn, hidden_state, None)
+        output = self._run_test(attn, hidden_state, attention_mask)
+        self.assertTrue(torch.allclose(output, output_nonemask, atol=1e-7))
+
+        # test padding
+        attention_mask[:, :, :, -10:] = -1
+        self._run_test(attn, hidden_state, attention_mask)
+
+        # test same global attention on all examples
+        attention_mask[:, :, :, :10] = 1
+        self._run_test(attn, hidden_state, attention_mask)
+
+        # test same number of global attention but different locations
+        attention_mask[:] = 0
+        attention_mask[:, :, :, -10:] = -1
+        attention_mask[0, :, :, :10] = 1
+        attention_mask[1, :, :, 5:15] = 1
+        attention_mask[2, :, :, 10:20] = 1
+        self._run_test(attn, hidden_state, attention_mask)
+
+        # test variable number of global attention
+        attention_mask[:] = 0
+        attention_mask[:, :, :, -10:] = -1
+        attention_mask[0, :, :, 5:15] = 1
+        attention_mask[2, :, :, 13:17] = 1
+        self._run_test(attn, hidden_state, attention_mask)
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR includes the following: 

- A PyTorch implementation of the sliding window attention, we called it `sliding_chunks` because it splits the sequence into overlapping sliding chunks. It is limited in functionality (no dilation, no autoregressive, 2x memory), but more convenient (works on all devices, supports fp16, good for pretrain/finetune).

- Support for a variable number of global attention tokens on each batch: https://github.com/allenai/longformer/issues/5

- Updating the TriviaQA script to use `sliding_chunks` and to use fp16. 