### PR TITLE
Update Pytorch Lightning to stable release version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 transformers @ git+http://github.com/ibeltagy/transformers.git@longformer_encoder_decoder#egg=transformers
-pytorch-lightning @ git+http://github.com/ibeltagy/pytorch-lightning.git@v0.8.5_fixes#egg=pytorch-lightning
+pytorch-lightning==1.0.4
 torch==1.6.0
 tensorboardX
 test-tube==0.7.5


### PR DESCRIPTION
As discussed in #128, moving lightning to a stable release version should bring stability for more users.

I tried to run the tests but it seems there are hardcoded paths within them, would it be possible to verify that this PL version works with the tests?